### PR TITLE
makeの代わりに npm スクリプトを使いました。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,0 @@
-deploy:
-	git subtree push --prefix src/ . gh-pages
-	git push origin gh-pages:gh-pages
-server:
-	php -S localhost:8000 -t src
-open:
-	open http://kfug.github.io/frontconf2016/

--- a/README.md
+++ b/README.md
@@ -1,27 +1,34 @@
 # フロントエンドカンファレンス2016 本サイト制作
 
+http://kfug.github.io/frontconf2016 のソースコードです。
+
+## インストール
+
+必要なことは [nodejs](https://nodejs.org/en/) です。インストールした後はターミナルで`npm i`を読んでください。
+
 ## 運用フロー
 
 ````
-$ gulp
+$ npm run build
 ````
 
-ejsのwatch コンパイル
+でサイトのダイナミックのコンテンツをコンパイルできます。
+長い間の開発のために
 
 ````
-$ gulp bsync
+$ npm start
 ````
 
 ブラウザシンクの起動
 
 ````
-$ gulp image
+$ npm run image
 ````
 
 画像の圧縮・リサイズ
 
 ````
-$ make deploy
+$ npm run deploy
 ````
 
 デプロイ

--- a/gulp/browserSync.js
+++ b/gulp/browserSync.js
@@ -14,7 +14,4 @@ module.exports = function(){
     ], function(){
         browserSync.reload();
     });
-
-
-
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ gulp.task("image",require("./gulp/image-min.js"))
 // EJS
 gulp.task("ejs",require("./gulp/ejs.js"))
 gulp.task("sass",require("./gulp/sass.js"))
-gulp.task("bsync",require("./gulp/browserSync.js"))
+var bsync = gulp.task("bsync",require("./gulp/browserSync.js"))
 //
 //gulp.task("bower",require("./gulp/bower.js"))
 //
@@ -15,11 +15,12 @@ gulp.task("bsync",require("./gulp/browserSync.js"))
 //
 //gulp.task("webpack",require("./gulp/webpack.js"))
 
+gulp.task('build', ['image', 'ejs', 'sass']);
+gulp.task('start', ['image', 'bsync', 'watch']);
 gulp.task("watch",function(){
     gulp.watch('./ejs/**/*.ejs', ['ejs']);
     gulp.watch('./sass/**/*.scss', ['sass']);
     //gulp.watch('./script/**/*.js', ['babel']);
 });
 // 開発用
-gulp.task("default",["watch"])
-
+gulp.task("default",["start"])

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "frontconf2016",
   "version": "1.0.0",
   "description": "",
+  "private": true,
   "main": "index.js",
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "browser-sync": "^2.11.0",
     "ejs": "^2.3.4",
     "gulp": "^3.9.0",
+    "gulp-cli": "^1.1.0",
     "gulp-ejs": "^1.2.2",
     "gulp-gm": "0.0.8",
     "gulp-image-resize": "^0.7.1",
@@ -16,9 +19,13 @@
     "gulp-sass": "^2.1.1",
     "gulp-sitemap": "^2.2.0"
   },
-  "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "gulp start",
+    "images": "gulp images",
+    "ejs": "gulp ejs",
+    "sass": "gulp sass",
+    "build": "gulp build",
+    "deploy": "git subtree push --prefix src/ . gh-pages; git push origin gh-pages:gh-pages"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Scriptの小さな不便なことを修正のPRです。
- `gulp-cli`を-gインスットールせず `npm run ...`に書き換えました。
- `make`のスクリプト → `npm run`に移動しました。
- `npm start`で`bsync`と`watch`のシステムがスタートするようにしました。

私にはやくに立っています。どうでしょうか？
